### PR TITLE
Security upgrade org.springframework:spring-context from 5.3.19 to 5.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Compile dependencies versions -->
         <commons-lang.version>3.12.0</commons-lang.version>
-        <spring.version>5.3.19</spring.version>
+        <spring.version>5.3.20</spring.version>
         <logback.version>1.2.11</logback.version>
         <performetrics.version>2.2.4</performetrics.version>
         <confectory.version>2.1.0</confectory.version>


### PR DESCRIPTION
## Overview

A new, medium-severity **Denial of Service (DoS)** vulnerability was associated with Spring 5.3.19:


Vulnerable module: org.springframework:spring-beans
Introduced through: org.springframework:spring-context@5.3.19
Remediation: Upgrade to org.springframework:spring-context@5.3.20

[org.springframework:spring-beans](https://www.baeldung.com/spring-bean) is a package that is the basis for Spring Framework's IoC container. The BeanFactory interface provides an advanced configuration mechanism capable of managing any type of object.

Affected versions of this package are vulnerable to Denial of Service (DoS) if it relies on data binding to set a MultipartFile or javax.servlet.Part to a field in a model object.

[Denial of Service (DoS) vulnerability report](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313)