### PR TITLE
Upgrade to Cron Utilities 9.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <performetrics.version>2.3.0</performetrics.version>
         <confectory.version>2.1.0</confectory.version>
         <guava.version>31.1-jre</guava.version>
-        <cron-utils.version>9.1.6</cron-utils.version>
+        <cron-utils.version>9.1.7</cron-utils.version>
 
         <!-- Test dependencies versions -->
         <junit.version>5.8.2</junit.version>


### PR DESCRIPTION
This PR solves a high-severity vulnerability associated with one of the project dependencies.

### CVE-2021-41269
Vulnerable module: org.glassfish:javax.el
Introduced through: com.cronutils:cron-utils@9.1.6
#### Details
Affected versions of this package are vulnerable to Improper Input Validation. A bug in the ELParserTokenManager enables invalid EL expressions to be evaluated as if they were valid.

The bug seems to be in the parser’s grammar - $ or # followed by a character that is not {, $ or # will be treated as a literal expression. The pertinent case is when the character following the $ or # chars is a backslash. The parser will then consume the backslash as part of the literal expression and will leave the character that follows it unescaped.
